### PR TITLE
refactor: replace `cli-color` with `picocolors`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "grunt-decomment",
+  "version": "0.2.4",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "grunt-decomment",
+      "version": "0.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "decomment": "^0.8.3",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.10",
+        "npm": ">=1.4"
+      }
+    },
+    "node_modules/decomment": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/decomment/-/decomment-0.8.8.tgz",
+      "integrity": "sha512-xVbmniKld/kjjmoHjT0Ex35aa16zw29WEzSAflBcMawjqDtZlrR6wkSwYV0mwJYytDz8JEAYia5Pl8IJRXdWLg==",
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10",
+        "npm": ">=1.4"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "npm": ">=1.4"
   },
   "dependencies": {
-    "cli-color": "1.1",
-    "decomment": "^0.8.3"
-  },
-  "devDependencies": {}
+    "decomment": "^0.8.3",
+    "picocolors": "^1.1.1"
+  }
 }

--- a/tasks/decomment.js
+++ b/tasks/decomment.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var decomment = require('decomment');
-var color = require('cli-color');
+var color = require('picocolors');
 var path = require('path');
 
 module.exports = function (grunt) {


### PR DESCRIPTION
`cli-color` -> `es5-ext` detected as a virus

https://github.com/medikoo/es5-ext/issues/186